### PR TITLE
Better URL Detection

### DIFF
--- a/libraries/carabiner.php
+++ b/libraries/carabiner.php
@@ -1107,7 +1107,7 @@ class Carabiner {
 	*/
 	public static function isURL($string)
 	{
-		$pattern = '@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@';
+		$pattern = '@(((https?|ftp):)?//([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@';
 		return preg_match($pattern, $string);
 	}
 }

--- a/libraries/carabiner.php
+++ b/libraries/carabiner.php
@@ -932,15 +932,16 @@ class Carabiner {
 	private function _get_contents($ref)
 	{
 
-		if( $this->isURL($ref) && ( ini_get('allow_url_fopen') == 0 || $this->force_curl ) ):
+        $abs_ref = ( substr($ref, 0, 2) == '//' ) ? ('http:' . $ref) : $ref;
+
+        if( $this->isURL($abs_ref) && ( ini_get('allow_url_fopen') == 0 || $this->force_curl ) ):
 
 			$this->_load('curl');
-            $curl_ref = (substr($ref, 0, 2) == '//') ? ('http:' . $ref) : $ref;
-			$contents = $this->CI->curl->simple_get($curl_ref);
+			$contents = $this->CI->curl->simple_get($abs_ref);
 			
 		else:
 
-			$contents = file_get_contents( $ref );
+			$contents = file_get_contents( $abs_ref );
 			
 		endif;
 		

--- a/libraries/carabiner.php
+++ b/libraries/carabiner.php
@@ -935,7 +935,8 @@ class Carabiner {
 		if( $this->isURL($ref) && ( ini_get('allow_url_fopen') == 0 || $this->force_curl ) ):
 
 			$this->_load('curl');
-			$contents = $this->CI->curl->simple_get($ref);
+            $curl_ref = (substr($ref, 0, 2) == '//') ? ('http:' . $ref) : $ref;
+			$contents = $this->CI->curl->simple_get($curl_ref);
 			
 		else:
 


### PR DESCRIPTION
We noticed that Carabiner did not support [protocol-relative URLs](http://paulirish.com/2010/the-protocol-relative-url/) nor FTP URLs, both of which could easily be used within a web application to serve JavaScript or CSS files. The current version tries to write protocol-relative and FTP URLs as relative URLs, which obviously is not the desired intent.

This pull request updates the regular expression that detects a valid URL so it returns `true` for both protocol-relative as well as FTP URLs.

The `_get_contents()` function now prepends `http:` if a protocol-relative URL is found so that the standard HTTP protocol is used when getting the contents of protocol-relative URLs.
