### PR TITLE
Avoid multiple minimizing/combining processes running simultaneously

### DIFF
--- a/libraries/carabiner.php
+++ b/libraries/carabiner.php
@@ -866,6 +866,29 @@ class Carabiner {
 	*/
 	private function _combine($flag, $files, $filename)
 	{
+		// Create a file lock to avoid concurrent processes calling
+		// this function simulatously, and generting this file many
+		// times concurrently, which puts huge load on the server
+		$lock_filename = $this->cache_path.$filename.'.lock';
+		$file_lock = fopen($lock_filename,"w+");
+		if (!flock($file_lock, LOCK_EX | LOCK_NB)) {
+			// Could not get lock
+			fclose($file_lock);
+
+			// how many seconds to wait for
+			$wait_for = 20;
+
+			// wait for the file to be created
+			while ($wait_for > 0) {
+				if (file_exists($filename)) {
+					break;
+				}
+				$wait_for--;
+				sleep(1);
+			}
+
+			return;
+		}
 
 		$file_data = '';
 		
@@ -892,6 +915,9 @@ class Carabiner {
 		
 		$this->_cache( $filename, $file_data );
 
+		// release lock
+		flock($file_lock, LOCK_UN);
+		fclose($file_lock);
 	}
 
 


### PR DESCRIPTION
If the CSS/JS changes and is re-generated by Carabiner, there is a possibility that the web server could get many requests before the re-generation is complete, and each request will start re-generation process.  This leads to many processes generating the JS/CSS at the same time, causing extremely high load on the server.  This uses a file lock to avoid this situation, only the first request to hit the server will re-generate the CSS/JS and subsequent requests will wait for the file to be generated.
