### PR TITLE
Fix javascript error on combined files

### DIFF
--- a/libraries/carabiner.php
+++ b/libraries/carabiner.php
@@ -879,12 +879,12 @@ class Carabiner {
 			
 			if( (isset($file['minify']) && $file['minify'] == true) || (!isset($file['minify']) && $minify) ):
 				
-				$file_data .=  $this->_minify( $flag, $file['dev'] ) . $suffix ."\n";
+				$file_data .= rtrim( $this->_minify( $flag, $file['dev'] ), $suffix ) . $suffix ."\n";
 				
 			else:
 			
 				$r = ( $this->isURL($file[$v]) ) ? $file[$v] : realpath($path.$file[$v]);
-				$file_data .=  $this->_get_contents( $r ) . $suffix ."\n";
+				$file_data .=  rtrim( $this->_get_contents( $r ), $suffix ) . $suffix ."\n";
 				
 			endif;
 		

--- a/libraries/carabiner.php
+++ b/libraries/carabiner.php
@@ -868,23 +868,23 @@ class Carabiner {
 	{
 
 		$file_data = '';
-		
+
+		$js_suffix = $flag == 'js' ? ';' : '';		
 		$path = ($flag == 'css') ? $this->style_path : $this->script_path;
 		$minify = ($flag == 'css') ? $this->minify_css : $this->minify_js;
-		
-	
+
 		foreach($files as $file):
 			
 			$v = (isset($file['prod']) ) ? 'prod' : 'dev';
 			
 			if( (isset($file['minify']) && $file['minify'] == true) || (!isset($file['minify']) && $minify) ):
 				
-				$file_data .=  $this->_minify( $flag, $file['dev'] ) . "\n";
+				$file_data .=  $this->_minify( $flag, $file['dev'] ) . $js_suffix ."\n";
 				
 			else:
 			
 				$r = ( $this->isURL($file[$v]) ) ? $file[$v] : realpath($path.$file[$v]);
-				$file_data .=  $this->_get_contents( $r ) ."\n";
+				$file_data .=  $this->_get_contents( $r ) . $js_suffix ."\n";
 				
 			endif;
 		

--- a/libraries/carabiner.php
+++ b/libraries/carabiner.php
@@ -869,7 +869,7 @@ class Carabiner {
 
 		$file_data = '';
 
-		$js_suffix = $flag == 'js' ? ';' : '';		
+		$suffix = $flag == 'js' ? ';' : '';		
 		$path = ($flag == 'css') ? $this->style_path : $this->script_path;
 		$minify = ($flag == 'css') ? $this->minify_css : $this->minify_js;
 
@@ -879,12 +879,12 @@ class Carabiner {
 			
 			if( (isset($file['minify']) && $file['minify'] == true) || (!isset($file['minify']) && $minify) ):
 				
-				$file_data .=  $this->_minify( $flag, $file['dev'] ) . $js_suffix ."\n";
+				$file_data .=  $this->_minify( $flag, $file['dev'] ) . $suffix ."\n";
 				
 			else:
 			
 				$r = ( $this->isURL($file[$v]) ) ? $file[$v] : realpath($path.$file[$v]);
-				$file_data .=  $this->_get_contents( $r ) . $js_suffix ."\n";
+				$file_data .=  $this->_get_contents( $r ) . $suffix ."\n";
 				
 			endif;
 		


### PR DESCRIPTION
This prevent JavaScript error when combined files are not ending with a semi-colon character.
