### PR TITLE
Fix PHP deprecation warning

### DIFF
--- a/libraries/cssmin.php
+++ b/libraries/cssmin.php
@@ -60,7 +60,12 @@
 */
  
  class cssmin {
- 	
+
+	public function __construct()
+ 	{
+ 		$this->cssmin();
+ 	}
+
  	public function cssmin()
  	{
  		log_message('debug', 'CSSMin library initialized.');


### PR DESCRIPTION
This change fixes the "Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP" warning while maintaining compatibility with old PHP versions.